### PR TITLE
Command line-configurable memory limit

### DIFF
--- a/bmdcapture.cpp
+++ b/bmdcapture.cpp
@@ -875,7 +875,9 @@ bail:
     }
 
     if (deckLinkIterator != NULL)
+    {
         deckLinkIterator->Release();
+    }
 
     if (oc != NULL)
     {


### PR DESCRIPTION
Heya Luca,

thanks for merging all the previous changes!

I have yet another (for us important) change which permits a command-line configurable memory limit using the -M option. We need it for the reasons outlined in our previous pull request.

It would be great if you could merge it (along with the small coding style fix).

(Hopefully the last request for this year)

Thanks again!

Christian
