### PR TITLE
Fix for lu-zero/decklink-ffmpeg issue #3

### DIFF
--- a/compat.h
+++ b/compat.h
@@ -1,4 +1,5 @@
 #pragma once
+#include "DeckLinkAPI.h"
 
 #ifdef IID_IDeckLinkVideoConversion
     /* IID_IDeckLinkVideoConversion is only available in recent DeckLink SDKs,


### PR DESCRIPTION
The compatibility layer (compat.h) checks for availability of
certain SDK #defines. This -- of course -- can only work if the
SDK header files have been #include'd before.
During testing this was the case and did work as expected (due to
different #include ordering).
This fix now #include's the SDK header in compat.h, so that compat.h
is totally independent on #include ordering.
