### PR TITLE
fixing wallclock option not working

### DIFF
--- a/bmdcapture.cpp
+++ b/bmdcapture.cpp
@@ -734,6 +734,8 @@ int main(int argc, char *argv[])
             }
             break;
         case 'w':
+            wallclock = true;
+            break;
         case '?':
         case 'h':
             usage(0);


### PR DESCRIPTION
Hi Luca,

I saw that your -w option, which I'm interested in very much, is not working in the current git repository's status.
Please find the small patch to make it work ;) 

Also, I'm building a *wall clock synchronization* option for bmdcapture, allowing to drop or duplicate frames to ensure we have a number of frames corresponding to the capturing computer wallclock (we have cameras sending 62fps instead of 60, and sometime 58~59!... want to "synchronize" that...)

If you are interested, I'll pull request this option too later...