### PR TITLE
Handle pipe error or disk full/error in bmdcapture push_packet()

### DIFF
--- a/bmdcapture.cpp
+++ b/bmdcapture.cpp
@@ -629,8 +629,9 @@ static void *push_packet(void *ctx)
     int ret;
 
     while (avpacket_queue_get(&queue, &pkt, 1)) {
-        av_interleaved_write_frame(s, &pkt);
-        if ((g_maxFrames > 0 && frameCount >= g_maxFrames) ||
+        ret = av_interleaved_write_frame(s, &pkt);
+        if (ret || 
+	    (g_maxFrames > 0 && frameCount >= g_maxFrames) ||
             avpacket_queue_size(&queue) > g_memoryLimit) {
             pthread_cond_signal(&sleepCond);
         }


### PR DESCRIPTION
In push_packet functions, the return code of av_interleaved_write_frame is ignored.

We don't know if the outfile is in a disk error, disk full, or pipe issue state.
it seems you planned to do that by defining "ret" as an integer ;)
This patch handle this case.