### PR TITLE
Support for Decklink 11 and newer

### DIFF
--- a/modes.cpp
+++ b/modes.cpp
@@ -35,6 +35,8 @@ void print_display_mode(IDeckLinkDisplayMode *displayMode, int index)
 
     BMDTimeValue frameRateDuration;
     BMDTimeScale frameRateScale;
+    // This seems to be deprecated in newer Decklink SDK 11
+    // Since it is not needed in file it is commented out for now
     // BMDDisplayModeSupport displayModeSupport;
     BMDProbeString str;
 

--- a/modes.cpp
+++ b/modes.cpp
@@ -36,8 +36,6 @@ void print_display_mode(IDeckLinkDisplayMode *displayMode, int index)
     BMDTimeValue frameRateDuration;
     BMDTimeScale frameRateScale;
     // BMDDisplayModeSupport displayModeSupport;
-
-
     BMDProbeString str;
 
     if (displayMode->GetName(&str) != S_OK)

--- a/modes.cpp
+++ b/modes.cpp
@@ -35,7 +35,9 @@ void print_display_mode(IDeckLinkDisplayMode *displayMode, int index)
 
     BMDTimeValue frameRateDuration;
     BMDTimeScale frameRateScale;
-    BMDDisplayModeSupport displayModeSupport;
+    // BMDDisplayModeSupport displayModeSupport;
+
+
     BMDProbeString str;
 
     if (displayMode->GetName(&str) != S_OK)


### PR DESCRIPTION
The BMDDisplayModeSupport in modes.cpp seems to be dropped from the Decklink SDK. Since it is not used in the file anyway I just commented it out.